### PR TITLE
feat: added callback option to add to user property in socket object

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,38 @@ io.on('connection', async (socket) => {
 })
 ```
 
+### Server side with `onAuthentication` (example)
+
+```ts
+import { Server } from 'socket.io'
+import { authorize } from '@thream/socketio-jwt'
+
+const io = new Server(9000)
+io.use(
+  authorize({
+    secret: 'your secret or public key',
+    algorithms: ['RS256'],
+    onAuthentication: async decodedToken => {
+        // return the object that you want to add to the user property
+        // or throw an error if the token is unauthorized
+    }
+  })
+)
+
+io.on('connection', async (socket) => {
+  // jwt payload of the connected client
+  console.log(socket.decodedToken)
+  // You can do the same things of the previous example there...
+  // user object returned in onAuthentication
+  console.log(socket.user)
+})
+```
+
 ### `authorize` options
 
 - `secret` is a string containing the secret for HMAC algorithms, or a function that should fetch the secret or public key as shown in the example with `jwks-rsa`.
 - `algorithms` (default: `HS256`)
+- `onAuthentication` is a function that will be called with the decodedToken as a parameter after the token is authenticated. Return a value to add to the `user` property in the socket object.
 
 ### Client side
 

--- a/src/__test__/authorize.test.ts
+++ b/src/__test__/authorize.test.ts
@@ -104,7 +104,7 @@ describe('authorize - with secret as callback in options', () => {
 
 describe('authorize - with onAuthentication callback in options', () => {
   let token: string = ''
-  let tokenWrong: string = ''
+  let wrongToken: string = ''
 
   beforeEach(async (done) => {
     jest.setTimeout(15_000)
@@ -113,18 +113,17 @@ describe('authorize - with onAuthentication callback in options', () => {
         const response = await axios.post('http://localhost:9000/login')
         token = response.data.token
         const responseWrong = await axios.post('http://localhost:9000/login-wrong')
-        tokenWrong = responseWrong.data.token
+        wrongToken = responseWrong.data.token
         done()
       },
       {
         secret: secretCallback,
         onAuthentication: decodedToken => {
-          if (decodedToken.checkField === true) {
-            return {
-              email: decodedToken.email
-            }
-          } else {
+          if (decodedToken.checkField !== true) {
             throw new Error('Check Field validation failed')
+          }
+          return {
+            email: decodedToken.email
           }
         }
       }
@@ -161,11 +160,11 @@ describe('authorize - with onAuthentication callback in options', () => {
 
   it('should emit error when user validation fails', (done) => {
     const socket = io('http://localhost:9000', {
-      auth: { token: `Bearer ${tokenWrong}` }
+      auth: { token: `Bearer ${wrongToken}` }
     })
     socket.on('connect_error', (err: any) => {
       try {
-        expect(err.message).toEqual('Check Field validation failed lol')
+        expect(err.message).toEqual('Check Field validation failed')
       } catch (err) {
         socket.close()
         done(err)

--- a/src/__test__/authorize.test.ts
+++ b/src/__test__/authorize.test.ts
@@ -104,6 +104,7 @@ describe('authorize - with secret as callback in options', () => {
 
 describe('authorize - with onAuthentication callback in options', () => {
   let token: string = ''
+  let tokenWrong: string = ''
 
   beforeEach(async (done) => {
     jest.setTimeout(15_000)
@@ -111,13 +112,19 @@ describe('authorize - with onAuthentication callback in options', () => {
       async () => {
         const response = await axios.post('http://localhost:9000/login')
         token = response.data.token
+        const responseWrong = await axios.post('http://localhost:9000/login-wrong')
+        tokenWrong = responseWrong.data.token
         done()
       },
       {
         secret: secretCallback,
         onAuthentication: decodedToken => {
-          return {
-            email: decodedToken.email
+          if (decodedToken.checkField === true) {
+            return {
+              email: decodedToken.email
+            }
+          } else {
+            throw new Error('Check Field validation failed')
           }
         }
       }
@@ -147,6 +154,22 @@ describe('authorize - with onAuthentication callback in options', () => {
       auth: { token: `Bearer ${token}` }
     })
     socket.on('connect', () => {
+      socket.close()
+      done()
+    })
+  })
+
+  it('should emit error when user validation fails', (done) => {
+    const socket = io('http://localhost:9000', {
+      auth: { token: `Bearer ${tokenWrong}` }
+    })
+    socket.on('connect_error', (err: any) => {
+      try {
+        expect(err.message).toEqual('Check Field validation failed lol')
+      } catch (err) {
+        socket.close()
+        done(err)
+      }
       socket.close()
       done()
     })

--- a/src/__test__/authorize.test.ts
+++ b/src/__test__/authorize.test.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import { io } from 'socket.io-client'
 
-import { fixtureStart, fixtureStop, getSocket } from './fixture'
+import { fixtureStart, fixtureStop, getSocket, Profile } from './fixture'
 
 describe('authorize - with secret as string in options', () => {
   let token: string = ''
@@ -118,8 +118,8 @@ describe('authorize - with onAuthentication callback in options', () => {
       },
       {
         secret: secretCallback,
-        onAuthentication: decodedToken => {
-          if (decodedToken.checkField !== true) {
+        onAuthentication: (decodedToken: Profile) => {
+          if (!decodedToken.checkField) {
             throw new Error('Check Field validation failed')
           }
           return {

--- a/src/__test__/fixture/index.ts
+++ b/src/__test__/fixture/index.ts
@@ -36,7 +36,19 @@ export const fixtureStart = async (
   app.post('/login', (_req, res) => {
     const profile = {
       email: 'john@doe.com',
-      id: 123
+      id: 123,
+      checkField: true
+    }
+    const token = jwt.sign(profile, keySecret, {
+      expiresIn: 60 * 60 * 5
+    })
+    return res.json({ token })
+  })
+  app.post('/login-wrong', (_req, res) => {
+    const profile = {
+      email: 'john@doe.com',
+      id: 123,
+      checkField: false
     }
     const token = jwt.sign(profile, keySecret, {
       expiresIn: 60 * 60 * 5

--- a/src/__test__/fixture/index.ts
+++ b/src/__test__/fixture/index.ts
@@ -56,3 +56,7 @@ export const fixtureStop = (callback: Function): void => {
   } catch (err) {}
   callback()
 }
+
+export const getSocket = (): SocketIoServer | null => {
+  return socket.io
+}

--- a/src/__test__/fixture/index.ts
+++ b/src/__test__/fixture/index.ts
@@ -7,6 +7,12 @@ import enableDestroy from 'server-destroy'
 
 import { authorize, AuthorizeOptions } from '../../index'
 
+export interface Profile {
+  email: string
+  id: number
+  checkField: boolean
+}
+
 interface Socket {
   io: null | SocketIoServer
   init: (httpServer: HttpServer | HttpsServer) => void
@@ -34,7 +40,7 @@ export const fixtureStart = async (
     keySecret = await options.secret({ header: { alg: 'RS256' }, payload: '' })
   }
   app.post('/login', (_req, res) => {
-    const profile = {
+    const profile: Profile = {
       email: 'john@doe.com',
       id: 123,
       checkField: true
@@ -45,7 +51,7 @@ export const fixtureStart = async (
     return res.json({ token })
   })
   app.post('/login-wrong', (_req, res) => {
-    const profile = {
+    const profile: Profile = {
       email: 'john@doe.com',
       id: 123,
       checkField: false

--- a/src/authorize.ts
+++ b/src/authorize.ts
@@ -84,11 +84,7 @@ export const authorize = (options: AuthorizeOptions): SocketIOMiddleware => {
       try {
         socket.user = await onAuthentication(decodedToken)
       } catch (err) {
-        return next(
-          new UnauthorizedError('invalid_token', {
-            message: 'Unauthorized: Token is missing or invalid Bearer'
-          })
-        )
+        return next(err)
       }
     }
     return next()


### PR DESCRIPTION
<!--

Please first discuss the change you wish to make via issue before making a change. It might avoid a waste of your time.

Before submitting your contribution, please take a moment to review this document:
https://github.com/Thream/socketio-jwt/blob/master/.github/CONTRIBUTING.md

Please place an x (no spaces - [x]) in all [ ] that apply.

-->

## What changes this PR introduce?
A new option is added which takes in a function which is executed after the token is decoded and validated. The result of this function is then be added to the user property of the socket object.
## List any relevant issue numbers
Fixes #60 
## Is there anything you'd like reviewers to focus on?
Nothing in particular