### PR TITLE
Change "public" to "private" in README code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import { authorize } from '@thream/socketio-jwt'
 const io = new Server(9000)
 io.use(
   authorize({
-    secret: 'your secret or public key'
+    secret: 'your secret or private key'
   })
 )
 


### PR DESCRIPTION
Please ignore this if I'm mistaken, but reading The JWT Handbook, they refer to using your "private-key or secret" to sign data server-side. This is in line with expectations, and confirms my confusion when reading the code example for the usage of this package - you don't specify a public key, but a private one, right?

Again, please dismiss this PR if I misunderstood something. In that case, a clarification would be great :-)