### PR TITLE
feat: lookup auth header if token is not present in handshake

### DIFF
--- a/src/authorize.ts
+++ b/src/authorize.ts
@@ -42,6 +42,9 @@ export const authorize = (options: AuthorizeOptions): SocketIOMiddleware => {
   return async (socket, next) => {
     let encodedToken: string | null = null
     const { token } = socket.handshake.auth
+    if (token == null) {
+      token = socket.handshake.headers.authorization
+    }
     if (token != null) {
       const tokenSplitted = token.split(' ')
       if (tokenSplitted.length !== 2 || tokenSplitted[0] !== 'Bearer') {


### PR DESCRIPTION
## What changes this PR introduce?
If a middleware sets the token for the request, its not present in the handshake and therefore not authorized. This supports also a auth header.

## List any relevant issue numbers

## Is there anything you'd like reviewers to focus on?
